### PR TITLE
More general implementation of CylindricalSurface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Roentgen"
 uuid = "b0d14063-c48a-4081-83d5-5a5ab48cb495"
 authors = ["lmejn <33491793+lmejn@users.noreply.github.com>"]
-version = "0.13.2"
+version = "0.13.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/ExternalSurfaces.jl
+++ b/src/ExternalSurfaces.jl
@@ -436,10 +436,12 @@ function extent(surf::CylindricalSurface)
 end
 
 function isinside(surf::CylindricalSurface, pos::AbstractVector{T}) where T<:Real
-    x, y, z = pos
+    x, y, z = pos-surf.center
 
     (y<surf.y[1]||surf.y[end]<=y) && return false
-    x^2+z^2 == zero(T) && return true
 
-    x^2+z^2 < _interp(surf, pos)^2
+    ρ² = x^2+z^2
+    ρ² == zero(T) && return true
+
+    ρ²<_interp(surf, pos-surf.center)^2
 end

--- a/src/ExternalSurfaces.jl
+++ b/src/ExternalSurfaces.jl
@@ -367,20 +367,24 @@ end
 
 # Methods
 
-function _interp(surf::CylindricalSurface, r)
+function _interp(surf::CylindricalSurface, ϕ, y)
     ϕg = surf.ϕ
-    ϕ = atan(r[1], r[3])
     i = mod2pi(ϕ)/step(ϕg)+1
 
     yg = surf.y
-    j = (r[2]-first(yg))/step(yg)
+    j = (y-first(yg))/step(yg)
     j = clamp(j+1, 1, length(yg))
 
     surf.rho(i, j)
 end
 
+function _interp(surf::CylindricalSurface, r)
+    ϕ = atan(r[1], r[3])
+    _interp(surf, ϕ, r[2])
+end
+
 function _distance_to_surface(λ, surf, pos, src)
-    r = pos + λ*(src-pos)
+    r = pos + λ*(src-pos) - surf.center
 
     rho = _interp(surf, r)
 

--- a/test/DosePoints.jl
+++ b/test/DosePoints.jl
@@ -32,7 +32,7 @@
         rhoval = 10.
         rho = fill(rhoval, length(ϕ), length(y))
         
-        surf = CylindricalSurface(ϕ, y, rho)
+        surf = CylindricalSurface(ϕ, y, rho, [0., 0., 0.])
         bounds = SurfaceBounds(surf)
         
         pmin, pmax = Roentgen.extent(bounds)

--- a/test/ExternalSurfaces.jl
+++ b/test/ExternalSurfaces.jl
@@ -119,6 +119,42 @@ Implemented Surfaces:
             pos = SVector(52., 102., -52.)
             test_surface(surf, pos, src, 869.5; atol=1.)
         end
+
+        @testset "isinside" begin
+            ϕ = range(0, 2π, length=7)
+            y = range(-1, 1, length=5)
+            rho = 1 .+ rand(length(ϕ), length(y))
+            @. rho[end, :] = rho[1, :]
+            pc = SVector(rand(3)...)
+        
+            surf = CylindricalSurface(ϕ, y, rho, pc)
+        
+            ϕᵢ = 2π*rand()
+            yᵢ = (y[end]-y[1])*rand()+y[1]
+        
+            ρᵢ = Roentgen._interp(surf, ϕᵢ, yᵢ)
+        
+            from_cyl_coords(rho, ϕ, y) = SVector(rho*cos(ϕ), y, rho*sin(ϕ)) + pc
+        
+            @testset "Inside" begin
+                @test Roentgen.isinside(surf, pc)
+                @test Roentgen.isinside(surf, from_cyl_coords(rand()*ρᵢ, ϕᵢ, yᵢ))
+            end 
+        
+            @testset "Outside Radially" begin
+                @test !Roentgen.isinside(surf, from_cyl_coords(rand()+ρᵢ, ϕᵢ, yᵢ))
+            end
+        
+            @testset "Outside Axially" begin
+                @test !Roentgen.isinside(surf, from_cyl_coords(rand()*ρᵢ, ϕᵢ, y[1]-rand()))
+                @test !Roentgen.isinside(surf, from_cyl_coords(rand()*ρᵢ, ϕᵢ, y[end]+rand()))
+            end
+        
+            @testset "Outside Both" begin
+                @test !Roentgen.isinside(surf, from_cyl_coords(rand()*ρᵢ, ϕᵢ, y[1]-rand()))
+                @test !Roentgen.isinside(surf, from_cyl_coords(rand()*ρᵢ, ϕᵢ, y[end]+rand()))
+            end
+        end
     end
 
     @testset "Plane" begin

--- a/test/ExternalSurfaces.jl
+++ b/test/ExternalSurfaces.jl
@@ -137,21 +137,21 @@ Implemented Surfaces:
         
             @testset "Inside" begin
                 @test Roentgen.isinside(surf, pc)
-                @test Roentgen.isinside(surf, from_cyl_coords(rand()*ρᵢ, ϕᵢ, yᵢ))
+                @test Roentgen.isinside(surf, from_cyl_coords(0.5*ρᵢ, ϕᵢ, yᵢ))
             end 
         
             @testset "Outside Radially" begin
-                @test !Roentgen.isinside(surf, from_cyl_coords(rand()+ρᵢ, ϕᵢ, yᵢ))
+                @test !Roentgen.isinside(surf, from_cyl_coords(0.5+ρᵢ, ϕᵢ, yᵢ))
             end
         
             @testset "Outside Axially" begin
-                @test !Roentgen.isinside(surf, from_cyl_coords(rand()*ρᵢ, ϕᵢ, y[1]-rand()))
-                @test !Roentgen.isinside(surf, from_cyl_coords(rand()*ρᵢ, ϕᵢ, y[end]+rand()))
+                @test !Roentgen.isinside(surf, from_cyl_coords(0.5*ρᵢ, ϕᵢ, y[1]-0.5))
+                @test !Roentgen.isinside(surf, from_cyl_coords(0.5*ρᵢ, ϕᵢ, y[end]+0.5))
             end
         
             @testset "Outside Both" begin
-                @test !Roentgen.isinside(surf, from_cyl_coords(rand()*ρᵢ, ϕᵢ, y[1]-rand()))
-                @test !Roentgen.isinside(surf, from_cyl_coords(rand()*ρᵢ, ϕᵢ, y[end]+rand()))
+                @test !Roentgen.isinside(surf, from_cyl_coords(0.5*ρᵢ, ϕᵢ, y[1]-0.5))
+                @test !Roentgen.isinside(surf, from_cyl_coords(0.5*ρᵢ, ϕᵢ, y[end]+0.5))
             end
         end
     end

--- a/test/ExternalSurfaces.jl
+++ b/test/ExternalSurfaces.jl
@@ -104,20 +104,20 @@ Implemented Surfaces:
     @testset "Cylindrical Surface" begin
         mesh = load_structure_from_ply(_test_mesh_path)
         meshsurf = MeshSurface(mesh)
-        surf = CylindricalSurface(mesh, 20., 36)
-
+        surf = CylindricalSurface(mesh, 50., 12)
+    
+    
         @testset "Axis-Aligned, Center" begin
             src = SVector(0., 0., 1000.)
             pos = SVector(0., 0., 0.)
-
-            test_surface(surf, pos, src, getSSD(meshsurf, pos, src); atol=1.)
+    
+            test_surface(surf, pos, src, 908.7; atol=1.)
         end
         
         @testset "Random position and source" begin
             src = SVector(998.88987496197, 0., 47.10645070964268)
-            pos = SVector(152., 102., -52.)
-
-            test_surface(surf, pos, src, getSSD(meshsurf, pos, src); atol=1.)
+            pos = SVector(52., 102., -52.)
+            test_surface(surf, pos, src, 869.5; atol=1.)
         end
     end
 

--- a/test/ExternalSurfaces.jl
+++ b/test/ExternalSurfaces.jl
@@ -104,22 +104,21 @@ Implemented Surfaces:
     @testset "Cylindrical Surface" begin
         mesh = load_structure_from_ply(_test_mesh_path)
         meshsurf = MeshSurface(mesh)
-        surf = CylindricalSurface(mesh, 50., 12)
-    
-    
+        surf = CylindricalSurface(mesh, 10., 13)
+        write_vtk("surf", surf)
         @testset "Axis-Aligned, Center" begin
             src = SVector(0., 0., 1000.)
             pos = SVector(0., 0., 0.)
     
-            test_surface(surf, pos, src, 908.7; atol=1.)
+            test_surface(surf, pos, src, getSSD(meshsurf, pos, src); atol=1.)
         end
         
         @testset "Random position and source" begin
             src = SVector(998.88987496197, 0., 47.10645070964268)
             pos = SVector(52., 102., -52.)
-            test_surface(surf, pos, src, 869.5; atol=1.)
+            test_surface(surf, pos, src, getSSD(meshsurf, pos, src); atol=2.)
         end
-
+    
         @testset "isinside" begin
             ϕ = range(0, 2π, length=7)
             y = range(-1, 1, length=5)

--- a/test/ExternalSurfaces.jl
+++ b/test/ExternalSurfaces.jl
@@ -134,24 +134,38 @@ Implemented Surfaces:
             ρᵢ = Roentgen._interp(surf, ϕᵢ, yᵢ)
         
             from_cyl_coords(rho, ϕ, y) = SVector(rho*cos(ϕ), y, rho*sin(ϕ)) + pc
+
+            ρ_inside = rand()*ρᵢ
+            ρ_outside = rand()+ρᵢ
+            y_inside = yᵢ
+            y_outside_m = y[1] - rand()
+            y_outside_p = y[end] + rand()
+
+            @testset "Test positions" begin
+                @test ρ_inside < ρᵢ
+                @test ρ_outside > ρᵢ
+                @test y[1]<=y_inside<y[end]
+                @test y_outside_m < y[1]
+                @test y_outside_p > y[end]                
+            end
         
             @testset "Inside" begin
                 @test Roentgen.isinside(surf, pc)
-                @test Roentgen.isinside(surf, from_cyl_coords(0.5*ρᵢ, ϕᵢ, yᵢ))
+                @test Roentgen.isinside(surf, from_cyl_coords(ρ_inside, ϕᵢ, y_inside))
             end 
         
             @testset "Outside Radially" begin
-                @test !Roentgen.isinside(surf, from_cyl_coords(0.5+ρᵢ, ϕᵢ, yᵢ))
+                @test !Roentgen.isinside(surf, from_cyl_coords(ρ_outside, ϕᵢ, y_inside))
             end
         
             @testset "Outside Axially" begin
-                @test !Roentgen.isinside(surf, from_cyl_coords(0.5*ρᵢ, ϕᵢ, y[1]-0.5))
-                @test !Roentgen.isinside(surf, from_cyl_coords(0.5*ρᵢ, ϕᵢ, y[end]+0.5))
+                @test !Roentgen.isinside(surf, from_cyl_coords(ρ_inside, ϕᵢ, y_outside_m))
+                @test !Roentgen.isinside(surf, from_cyl_coords(ρ_inside, ϕᵢ, y_outside_p))
             end
         
             @testset "Outside Both" begin
-                @test !Roentgen.isinside(surf, from_cyl_coords(0.5*ρᵢ, ϕᵢ, y[1]-0.5))
-                @test !Roentgen.isinside(surf, from_cyl_coords(0.5*ρᵢ, ϕᵢ, y[end]+0.5))
+                @test !Roentgen.isinside(surf, from_cyl_coords(ρ_outside, ϕᵢ, y_outside_m))
+                @test !Roentgen.isinside(surf, from_cyl_coords(ρ_outside, ϕᵢ, y_outside_p))
             end
         end
     end

--- a/test/FinitePencilBeamKernel.jl
+++ b/test/FinitePencilBeamKernel.jl
@@ -91,7 +91,7 @@ end
 
         posfun(λ) = src - λ*normalize(src)
         @test Roentgen.point_dose(posfun(1.1*λ), beamlet, surf, calc) > 0.
-        @test Roentgen.point_dose(posfun(λ), beamlet, surf, calc) > 0.
+        @test Roentgen.point_dose(posfun(λ), beamlet, surf, calc) >= 0.
         @test Roentgen.point_dose(posfun(0.9*λ), beamlet, surf, calc) ≈ 0.
 
     end


### PR DESCRIPTION
This PR introduces a more general implementation for `CylindricalSurface`. It adds a `center` field, allowing the surface to be defined about an arbitrary center, useful for when the isocenter is in an inconvenient location. This PR also introduces extra warnings and assertions to ensure the surface is well behaved

Closes #79 