### PR TITLE
Kernel Truncation in `reconstruct_dose`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Roentgen"
 uuid = "b0d14063-c48a-4081-83d5-5a5ab48cb495"
 authors = ["lmejn <33491793+lmejn@users.noreply.github.com>"]
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/DoseReconstructions.jl
+++ b/src/DoseReconstructions.jl
@@ -8,18 +8,20 @@ export reconstruct_dose
 
 """
     reconstruct_dose(vol::AbstractDoseVolume, plan::AbstractTreatmentPlan,
-        calc::AbstractDoseAlgorithm; Δx=5., show_progress=true)
+        calc::AbstractDoseAlgorithm; Δx=5., show_progress=true, maxradius=100.)
 
 Dose reconstruction from a treatment plan.
 
-Requires a dose volume (`vol`), a treatment plan (`plan`), and a dose calculation\
-algorithm (`calc`). 
+Requires a dose volume (`vol`), a treatment plan (`plan`), and a dose calculation
+algorithm (`calc`).
+
 Optional arguments include:
 - `Δx`: Size of each bixel in the fluence grid (defaults to 5.)
 - `show_progress`: If true (default), displays the progress
+- `maxradius`: Kernel truncation radius
 """
 function reconstruct_dose(vol::AbstractDoseVolume, plan::AbstractTreatmentPlan,
-    calc::AbstractDoseAlgorithm; Δx=5., show_progress=true)
+    calc::AbstractDoseAlgorithm; Δx=5., show_progress=true, maxradius=100.)
 
     pos = getpositions(vol)
     surf = getsurface(vol)
@@ -51,7 +53,8 @@ function reconstruct_dose(vol::AbstractDoseVolume, plan::AbstractTreatmentPlan,
             resize!(Ψ, nbixels)
         
             dose .+= ΔMU*sum(dose_fluence_matrix(SparseMatrixCSC, vec(pos_fixed),
-                                                 vec(beamlets), surf, calc);
+                                                 vec(beamlets), surf, calc;
+                                                 maxradius=maxradius);
                              dims=2)
             
             if(show_progress)

--- a/src/DoseReconstructions.jl
+++ b/src/DoseReconstructions.jl
@@ -29,15 +29,15 @@ function reconstruct_dose(vol::AbstractDoseVolume, plan::AbstractTreatmentPlan,
     dose = zeros(length(pos))
     Ψ = zeros(1)
 
+    if(show_progress)
+        totalMU = 0.
+        progress = Progress(sum(length.(plan)))
+    end
+
     # Iterate through each field in the plan
     for field in plan
 
         pos_fixed = patient_to_fixed(getisocenter(field)).(pos)
-
-        if(show_progress)
-            totalMU = 0.
-            p = Progress(length(field))
-        end
 
         # Iterate through each control point in the field
         for beam in field
@@ -58,10 +58,10 @@ function reconstruct_dose(vol::AbstractDoseVolume, plan::AbstractTreatmentPlan,
                              dims=2)
             
             if(show_progress)
-                next!(p; showvalues=[(:MU, totalMU+=ΔMU)])
+                next!(progress; showvalues=[(:MU, totalMU+=ΔMU)])
             end
-
         end
+
     end
     dose
 end

--- a/test/ExternalSurfaces.jl
+++ b/test/ExternalSurfaces.jl
@@ -135,7 +135,7 @@ Implemented Surfaces:
         
             from_cyl_coords(rho, ϕ, y) = SVector(rho*cos(ϕ), y, rho*sin(ϕ)) + pc
 
-            ρ_inside = rand()*ρᵢ
+            ρ_inside = 0.8*ρᵢ
             ρ_outside = rand()+ρᵢ
             y_inside = yᵢ
             y_outside_m = y[1] - rand()


### PR DESCRIPTION
Implemented kernel truncation in dose reconstruction. This is achieved by supplying `maxradius` to `reconstruct_dose`.

Minor changes include changing how progress is measured by the progress meter. It now shows the total progress instead of the progress per field.