### PR TITLE
Tidied IO code and added VTK Beamlet writer

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "src/IO"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Roentgen"
 uuid = "b0d14063-c48a-4081-83d5-5a5ab48cb495"
 authors = ["lmejn <33491793+lmejn@users.noreply.github.com>"]
-version = "0.13.4"
+version = "0.13.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/DoseCalculationAlgorithms/FinitePencilBeamKernel.jl
+++ b/src/DoseCalculationAlgorithms/FinitePencilBeamKernel.jl
@@ -62,60 +62,6 @@ source_position(beamlet::Beamlet) = source_axis_distance(beamlet)*source_axis(be
 
 tanθ_to_source(beamlet::Beamlet) = beamlet.tanθ
 
-# VTK IO
-"""
-    _vtk_beamlet_points(beamlet, L)
-
-Computes the vertices of the pyramid covered by a beamlet.
-
-See `write_vtk(filename, beamlet::Beamlet, L=2)` for further details
-"""
-function _vtk_beamlet_points(beamlet, L)
-    s = Roentgen.source_position(beamlet)
-    D = L*Roentgen.source_axis_distance(beamlet)
-    ax, ay, az = Roentgen.beamlet_axes(beamlet)
-    wx, wy = L.*Roentgen.halfwidth(beamlet)
-
-    (s,) .+ [D*az+wx*ax+wy*ay, D*az-wx*ax+wy*ay, D*az-wx*ax-wy*ay, D*az+wx*ax-wy*ay, zeros(3)]
-end
-
-"""
-    write_vtk(filename, mesh::Beamlet, L=2)
-
-Save a `Beamlet` to a VTK (.vtu) file.
-
-The beamlet is drawn from the source position to a length determined by parameter
-`L`. This is the length of the beamlet in units of source-axis distance.
-"""
-function write_vtk(filename, beamlet::Beamlet, L=2)
-    points = _vtk_beamlet_points(beamlet, L)
-    cells = [MeshCell(VTKCellTypes.VTK_PYRAMID, collect(1:5))]
-    vtk = vtk_grid(filename, points, cells)
-    vtk_save(vtk)
-end
-
-"""
-    write_vtk(filename, mesh::Vector{<:AbstractBeamlet}, L=2)
-
-Save a vector of `Beamlet` to a VTK (.vtu) file.
-
-See `write_vtk(filename, beamlet::Beamlet, L=2)` for further details
-"""
-function write_vtk(filename, beamlets::Vector{<:AbstractBeamlet}, L=2)
-    n = length(beamlets)
-
-    points = SVector{3, Float64}[]
-    for i in eachindex(beamlets)
-        append!(points, _vtk_beamlet_points(beamlets[i], L))
-    end
-
-    indices =  reshape(1:n*5, 5, n)
-    cells = MeshCell.((VTKCellTypes.VTK_PYRAMID,), eachcol(indices))
-
-    vtk = vtk_grid(filename, points, cells)
-    vtk_save(vtk)
-end
-
 """
     FinitePencilBeamKernel(parameters, scalingfactor, depth, tanθ)
 

--- a/src/DoseCalculationAlgorithms/FinitePencilBeamKernel.jl
+++ b/src/DoseCalculationAlgorithms/FinitePencilBeamKernel.jl
@@ -62,6 +62,35 @@ source_position(beamlet::Beamlet) = source_axis_distance(beamlet)*source_axis(be
 
 tanθ_to_source(beamlet::Beamlet) = beamlet.tanθ
 
+# VTK IO
+"""
+    _vtk_beamlet_points(beamlet, L)
+
+Computes the vertices of the pyramid covered by a beamlet.
+
+See `write_vtk(filename, beamlet::Beamlet, L=2)` for further details
+"""
+function _vtk_beamlet_points(beamlet, L)
+    s = Roentgen.source_position(beamlet)
+    D = L*Roentgen.source_axis_distance(beamlet)
+    ax, ay, az = Roentgen.beamlet_axes(beamlet)
+    wx, wy = L.*Roentgen.halfwidth(beamlet)
+
+    (s,) .+ [D*az+wx*ax+wy*ay, D*az-wx*ax+wy*ay, D*az-wx*ax-wy*ay, D*az+wx*ax-wy*ay, zeros(3)]
+end
+
+"""
+    write_vtk(filename, mesh::Beamlet, L=2)
+
+Save a `Beamlet` to a VTK (.vtu) file.
+"""
+function write_vtk(filename, beamlet::Beamlet, L=2)
+    points = _vtk_beamlet_points(beamlet, L)
+    cells = [MeshCell(VTKCellTypes.VTK_PYRAMID, collect(1:5))]
+    vtk = vtk_grid(filename, points, cells)
+    vtk_save(vtk)
+end
+
 """
     FinitePencilBeamKernel(parameters, scalingfactor, depth, tanθ)
 

--- a/src/DoseCalculationAlgorithms/FinitePencilBeamKernel.jl
+++ b/src/DoseCalculationAlgorithms/FinitePencilBeamKernel.jl
@@ -83,6 +83,9 @@ end
     write_vtk(filename, mesh::Beamlet, L=2)
 
 Save a `Beamlet` to a VTK (.vtu) file.
+
+The beamlet is drawn from the source position to a length determined by parameter
+`L`. This is the length of the beamlet in units of source-axis distance.
 """
 function write_vtk(filename, beamlet::Beamlet, L=2)
     points = _vtk_beamlet_points(beamlet, L)
@@ -91,13 +94,22 @@ function write_vtk(filename, beamlet::Beamlet, L=2)
     vtk_save(vtk)
 end
 
+"""
+    write_vtk(filename, mesh::Vector{<:AbstractBeamlet}, L=2)
+
+Save a vector of `Beamlet` to a VTK (.vtu) file.
+
+See `write_vtk(filename, beamlet::Beamlet, L=2)` for further details
+"""
 function write_vtk(filename, beamlets::Vector{<:AbstractBeamlet}, L=2)
+    n = length(beamlets)
+
     points = SVector{3, Float64}[]
     for i in eachindex(beamlets)
         append!(points, _vtk_beamlet_points(beamlets[i], L))
     end
 
-    indices =  reshape(1:length(bixels)*5, 5, length(bixels))
+    indices =  reshape(1:n*5, 5, n)
     cells = MeshCell.((VTKCellTypes.VTK_PYRAMID,), eachcol(indices))
 
     vtk = vtk_grid(filename, points, cells)

--- a/src/DoseCalculationAlgorithms/FinitePencilBeamKernel.jl
+++ b/src/DoseCalculationAlgorithms/FinitePencilBeamKernel.jl
@@ -91,6 +91,19 @@ function write_vtk(filename, beamlet::Beamlet, L=2)
     vtk_save(vtk)
 end
 
+function write_vtk(filename, beamlets::Vector{<:AbstractBeamlet}, L=2)
+    points = SVector{3, Float64}[]
+    for i in eachindex(beamlets)
+        append!(points, _vtk_beamlet_points(beamlets[i], L))
+    end
+
+    indices =  reshape(1:length(bixels)*5, 5, length(bixels))
+    cells = MeshCell.((VTKCellTypes.VTK_PYRAMID,), eachcol(indices))
+
+    vtk = vtk_grid(filename, points, cells)
+    vtk_save(vtk)
+end
+
 """
     FinitePencilBeamKernel(parameters, scalingfactor, depth, tanθ)
 

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -217,29 +217,6 @@ end
 
 Base.display(pos::DoseGrid) = display(getaxes(pos))
 
-#-- IO 
-
-function get_nrrd_props(pos::AbstractDoseGrid)
-    x, y, z = getaxes(pos)
-    origin = x[1], y[1], z[1]
-    directions = (step(x), 0, 0), (0, step(y), 0), (0, 0, step(z))
-    
-    Dict("space origin"=>origin,
-         "space directions"=>directions,
-         "space"=>"left-posterior-superior",
-         "kinds"=>("domain", "domain", "domain"))
-end
-
-"""
-    write_nrrd(filename::String, pos::DoseGrid, data::AbstractArray)
-
-Write `DoseGrid` to the NRRD data format.
-"""
-function write_nrrd(filename::String, pos::DoseGrid, data::AbstractArray)
-    props = get_nrrd_props(pos::AbstractDoseGrid)
-    FileIO.save(filename, reshape(data, size(pos)), props=props)
-end
-
 #--- DoseGridMasked ----------------------------------------------------------------------------------------------------
 """
     DoseGridMasked
@@ -329,26 +306,4 @@ function Base.show(io::IO, pos::DoseGridMasked)
     print(io, " z=")
     Base.show(io, pos.axes[3])
     println(io, " npts=", length(pos.indices))
-end
-
-# VTK
-
-"""
-    write_nrrd(filename::String, pos::DoseGridMasked, data::AbstractArray; fillvalue=NaN)
-
-Write `DoseGridMasked` to the NRRD data format.
-
-Masked points in `DoseGridMasked` are filled with `fillvalue`, defaults to `NaN`.
-"""
-function write_nrrd(filename::String, pos::DoseGridMasked, data::AbstractArray; fillvalue=NaN)
-
-    props = get_nrrd_props(pos)
-
-    datagrid = fill(fillvalue, gridsize(pos)...)
-    for i in eachindex(data)
-        I = pos.indices[i]
-        datagrid[I] = data[i]
-    end
-    
-    FileIO.save(filename, datagrid, props=props)
 end

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -219,20 +219,6 @@ Base.display(pos::DoseGrid) = display(getaxes(pos))
 
 #-- IO 
 
-"""
-    write_vtk(filename::String, pos::DoseGrid, data::Union{Vararg, Dict})
-
-Save `DoseGrid` to the VTK Image data (vti) format.
-"""
-function write_vtk(filename::String, pos::DoseGrid, data::Vararg)
-    vtk_grid(filename, pos.axes...) do vtkfile
-        for (key, value) in data
-            vtkfile[key, VTKPointData()] = value
-        end
-    end
-end
-write_vtk(filename::String, pos::DoseGrid, data::Dict) =  write_vtk(filename, pos, data...)
-
 function get_nrrd_props(pos::AbstractDoseGrid)
     x, y, z = getaxes(pos)
     origin = x[1], y[1], z[1]
@@ -346,68 +332,6 @@ function Base.show(io::IO, pos::DoseGridMasked)
 end
 
 # VTK
-
-"""
-    _get_cells(pos)
-
-Returns a list of cell connectivities
-"""
-function _get_cells(pos)
-    neighbours = vec([CartesianIndex(i,j,k) for i=0:1, j=0:1, k=0:1])[2:end]
-
-    indices = CartesianIndices(pos)
-    linear_index = zeros(gridsize(pos))
-
-    for i in eachindex(pos)
-        linear_index[indices[i]] = i
-    end
-
-    cells = Vector{Int}[]
-    for i in eachindex(indices)
-        cell = [i]
-    
-        for n in neighbours
-            index = indices[i] + n
-            if(checkbounds(Bool, linear_index, index) && linear_index[index]!=0)
-                push!(cell, linear_index[index])
-            end
-        end
-        if(length(cell)==8)
-            push!(cells, cell)
-        end
-    end
-    cells
-end
-
-"""
-    _vtk_create_cell(cell)
-
-Return the VTK cell type for a list of cell indices.
-"""
-function _vtk_create_cell(cell)
-    n = length(cell)
-    n==5 && return MeshCell(VTKCellTypes.VTK_PYRAMID, cell)
-    n==6 && return MeshCell(VTKCellTypes.VTK_WEDGE, cell)
-    n==8 && return MeshCell(VTKCellTypes.VTK_VOXEL, cell)
-end
-
-"""
-    write_vtk(filename::String, pos::DoseGridMasked, data::Union{Vararg, Dict})
-
-Save `DoseGridMasked` to the VTK Unstructured Grid (vtu) format.
-"""
-function write_vtk(filename::String, pos::DoseGridMasked, data::Vararg)
-    points = collect(pos)
-    
-    cells = _vtk_create_cell.(_get_cells(pos))
-
-    vtk_grid(filename, points, cells) do vtkfile
-        for (key, value) in data
-            vtkfile[key, VTKPointData()] = value
-        end
-    end
-end
-write_vtk(filename::String, pos::DoseGridMasked, data::Dict) =  write_vtk(filename, pos, data...)
 
 """
     write_nrrd(filename::String, pos::DoseGridMasked, data::AbstractArray; fillvalue=NaN)

--- a/src/ExternalSurfaces.jl
+++ b/src/ExternalSurfaces.jl
@@ -152,8 +152,6 @@ function getdepth(surf::MeshSurface, pos::T, src::T) where T<:Point
 end
 getdepth(surf::MeshSurface, pos, src) = getdepth(surf, Point(pos), Point(src))
 
-write_vtk(filename::String, surf::MeshSurface) = write_vtk(filename, surf.mesh)
-
 #--- Linear Surface ------------------------------------------------------------
 
 struct Plane{T}
@@ -424,26 +422,6 @@ function getdepth(surf::CylindricalSurface, pos::AbstractVector{T}, src::Abstrac
 
     λ = find_zero(f, lims, AlefeldPotraShi())
     λ*norm(src-pos)
-end
-
-function write_vtk(filename::String, surf::CylindricalSurface)
-    ϕ = surf.ϕ
-    y = surf.y
-    rho = Interpolations.coefficients(surf.rho)
-    @. rho[isinf(rho)] = NaN
-    xc, yc, zc = surf.center
-
-    x = @. xc + rho*sin(ϕ)
-    y = @. yc + surf.y
-    z = @. zc + rho*cos(ϕ)
-
-    xg = reshape(x, size(x)..., 1)
-    yg = ones(size(xg)).*y'
-    zg = reshape(z, size(z)..., 1)
-
-    vtk = vtk_grid(filename, xg, yg, zg)
-    vtk_save(vtk)
-
 end
 
 function extent(surf::CylindricalSurface)

--- a/src/IO/NRRD.jl
+++ b/src/IO/NRRD.jl
@@ -1,0 +1,41 @@
+
+function _get_nrrd_props(pos::AbstractDoseGrid)
+    x, y, z = getaxes(pos)
+    origin = x[1], y[1], z[1]
+    directions = (step(x), 0, 0), (0, step(y), 0), (0, 0, step(z))
+    
+    Dict("space origin"=>origin,
+         "space directions"=>directions,
+         "space"=>"left-posterior-superior",
+         "kinds"=>("domain", "domain", "domain"))
+end
+
+"""
+    write_nrrd(filename::String, pos::DoseGrid, data::AbstractArray)
+
+Write `DoseGrid` to the NRRD data format.
+"""
+function write_nrrd(filename::String, pos::DoseGrid, data::AbstractArray)
+    props = _get_nrrd_props(pos::AbstractDoseGrid)
+    FileIO.save(filename, reshape(data, size(pos)), props=props)
+end
+
+"""
+    write_nrrd(filename::String, pos::DoseGridMasked, data::AbstractArray; fillvalue=NaN)
+
+Write `DoseGridMasked` to the NRRD data format.
+
+Masked points in `DoseGridMasked` are filled with `fillvalue`, defaults to `NaN`.
+"""
+function write_nrrd(filename::String, pos::DoseGridMasked, data::AbstractArray; fillvalue=NaN)
+
+    props = _get_nrrd_props(pos)
+
+    datagrid = fill(fillvalue, gridsize(pos)...)
+    for i in eachindex(data)
+        I = pos.indices[i]
+        datagrid[I] = data[i]
+    end
+    
+    FileIO.save(filename, datagrid, props=props)
+end

--- a/src/IO/VTK.jl
+++ b/src/IO/VTK.jl
@@ -108,3 +108,17 @@ function write_vtk(filename::String, surf::CylindricalSurface)
     vtk_save(vtk)
 end
 
+#= Structures =========================================================================================================#
+
+"""
+    write_vtk(filename, mesh::SimpleMesh)
+
+Save a `SimpleMesh` to a VTK (.vtu) file.
+"""
+function write_vtk(filename, mesh::SimpleMesh)
+    id = [indices(e) for e in elements(topology(mesh))]
+    vtkfile = vtk_grid(filename,
+                       coordinates.(vertices(mesh)), 
+                       MeshCell.(Ref(VTKCellTypes.VTK_TRIANGLE), id))
+    vtk_save(vtkfile)
+end

--- a/src/IO/VTK.jl
+++ b/src/IO/VTK.jl
@@ -1,12 +1,25 @@
 
+
+"""
+    write_vtk(filename::String, data, args...)
+
+Write a data structure to the VTK file format.
+
+See the individual methods for information.
+"""
+write_vtk
+
 #= Dose Grids =========================================================================================================#
 
 #--- DoseGrid -----------------------------------------------------------------
 
 """
-    write_vtk(filename::String, pos::DoseGrid, data::Union{Vararg, Dict})
+    write_vtk(filename::String, pos::DoseGrid, "data1"=>data1, ...)
 
 Save `DoseGrid` to the VTK Image data (vti) format.
+
+Can add point data to visualise on the 3D grid by chaining `"name"=>data` pairs:
+e.g. `"dose"=>dose, "depth"=>depth`. Also supports `Dict`.
 """
 function write_vtk(filename::String, pos::DoseGrid, data::Vararg)
     vtk_grid(filename, pos.axes...) do vtkfile
@@ -20,9 +33,12 @@ write_vtk(filename::String, pos::DoseGrid, data::Dict) = write_vtk(filename, pos
 #--- DoseGridMasked -----------------------------------------------------------
 
 """
-    write_vtk(filename::String, pos::DoseGridMasked, data::Union{Vararg, Dict})
+    write_vtk(filename::String, pos::DoseGridMasked, "data1"=>data1, ...)
 
 Save `DoseGridMasked` to the VTK Unstructured Grid (vtu) format.
+
+Can add point data to visualise on the 3D grid by chaining `"name"=>data` pairs:
+e.g. `"dose"=>dose, "depth"=>depth`. Also supports `Dict`.
 """
 function write_vtk(filename::String, pos::DoseGridMasked, data::Vararg)
     points = collect(pos)
@@ -35,7 +51,7 @@ function write_vtk(filename::String, pos::DoseGridMasked, data::Vararg)
         end
     end
 end
-write_vtk(filename::String, pos::DoseGridMasked, data::Dict) =  write_vtk(filename, pos, data...)
+write_vtk(filename::String, pos::DoseGridMasked, data::Dict) = write_vtk(filename, pos, data...)
 
 """
     _get_cells(pos)
@@ -85,10 +101,20 @@ end
 
 #--- MeshSurface --------------------------------------------------------------
 
+"""
+    write_vtk(filename, surf::MeshSurface)
+
+Save a `MeshSurface` to a VTK (.vtu) file.
+"""
 write_vtk(filename::String, surf::MeshSurface) = write_vtk(filename, surf.mesh)
 
 #--- CylindricalSurface -------------------------------------------------------
 
+"""
+    write_vtk(filename, surf::CylindricalSurface)
+
+Save a `CylindricalSurface` to a VTK (.vtu) file.
+"""
 function write_vtk(filename::String, surf::CylindricalSurface)
     ϕ = surf.ϕ
     y = surf.y

--- a/src/IO/VTK.jl
+++ b/src/IO/VTK.jl
@@ -122,3 +122,58 @@ function write_vtk(filename, mesh::SimpleMesh)
                        MeshCell.(Ref(VTKCellTypes.VTK_TRIANGLE), id))
     vtk_save(vtkfile)
 end
+
+#= Beamlets ===========================================================================================================#
+
+"""
+    _vtk_beamlet_points(beamlet, L)
+
+Computes the vertices of the pyramid covered by a beamlet.
+
+See `write_vtk(filename, beamlet::Beamlet, L=2)` for further details
+"""
+function _vtk_beamlet_points(beamlet, L)
+    s = Roentgen.source_position(beamlet)
+    D = L*Roentgen.source_axis_distance(beamlet)
+    ax, ay, az = Roentgen.beamlet_axes(beamlet)
+    wx, wy = L.*Roentgen.halfwidth(beamlet)
+
+    (s,) .+ [D*az+wx*ax+wy*ay, D*az-wx*ax+wy*ay, D*az-wx*ax-wy*ay, D*az+wx*ax-wy*ay, zeros(3)]
+end
+
+"""
+    write_vtk(filename, mesh::Beamlet, L=2)
+
+Save a `Beamlet` to a VTK (.vtu) file.
+
+The beamlet is drawn from the source position to a length determined by parameter
+`L`. This is the length of the beamlet in units of source-axis distance.
+"""
+function write_vtk(filename, beamlet::Beamlet, L=2)
+    points = _vtk_beamlet_points(beamlet, L)
+    cells = [MeshCell(VTKCellTypes.VTK_PYRAMID, collect(1:5))]
+    vtk = vtk_grid(filename, points, cells)
+    vtk_save(vtk)
+end
+
+"""
+    write_vtk(filename, mesh::Vector{<:AbstractBeamlet}, L=2)
+
+Save a vector of `Beamlet` to a VTK (.vtu) file.
+
+See `write_vtk(filename, beamlet::Beamlet, L=2)` for further details
+"""
+function write_vtk(filename, beamlets::Vector{<:AbstractBeamlet}, L=2)
+    n = length(beamlets)
+
+    points = SVector{3, Float64}[]
+    for i in eachindex(beamlets)
+        append!(points, _vtk_beamlet_points(beamlets[i], L))
+    end
+
+    indices =  reshape(1:n*5, 5, n)
+    cells = MeshCell.((VTKCellTypes.VTK_PYRAMID,), eachcol(indices))
+
+    vtk = vtk_grid(filename, points, cells)
+    vtk_save(vtk)
+end

--- a/src/IO/VTK.jl
+++ b/src/IO/VTK.jl
@@ -1,0 +1,80 @@
+
+#--- DoseGrid ----------------------------------------------------------------------------------------------------------
+
+"""
+    write_vtk(filename::String, pos::DoseGrid, data::Union{Vararg, Dict})
+
+Save `DoseGrid` to the VTK Image data (vti) format.
+"""
+function write_vtk(filename::String, pos::DoseGrid, data::Vararg)
+    vtk_grid(filename, pos.axes...) do vtkfile
+        for (key, value) in data
+            vtkfile[key, VTKPointData()] = value
+        end
+    end
+end
+write_vtk(filename::String, pos::DoseGrid, data::Dict) = write_vtk(filename, pos, data...)
+
+#--- DoseGridMasked ---------------------------------------------------------------------------------------------------------
+
+"""
+    write_vtk(filename::String, pos::DoseGridMasked, data::Union{Vararg, Dict})
+
+Save `DoseGridMasked` to the VTK Unstructured Grid (vtu) format.
+"""
+function write_vtk(filename::String, pos::DoseGridMasked, data::Vararg)
+    points = collect(pos)
+    
+    cells = _vtk_create_cell.(_get_cells(pos))
+
+    vtk_grid(filename, points, cells) do vtkfile
+        for (key, value) in data
+            vtkfile[key, VTKPointData()] = value
+        end
+    end
+end
+write_vtk(filename::String, pos::DoseGridMasked, data::Dict) =  write_vtk(filename, pos, data...)
+
+"""
+    _get_cells(pos)
+
+Returns a list of cell connectivities
+"""
+function _get_cells(pos)
+    neighbours = vec([CartesianIndex(i,j,k) for i=0:1, j=0:1, k=0:1])[2:end]
+
+    indices = CartesianIndices(pos)
+    linear_index = zeros(gridsize(pos))
+
+    for i in eachindex(pos)
+        linear_index[indices[i]] = i
+    end
+
+    cells = Vector{Int}[]
+    for i in eachindex(indices)
+        cell = [i]
+    
+        for n in neighbours
+            index = indices[i] + n
+            if(checkbounds(Bool, linear_index, index) && linear_index[index]!=0)
+                push!(cell, linear_index[index])
+            end
+        end
+        if(length(cell)==8)
+            push!(cells, cell)
+        end
+    end
+    cells
+end
+
+"""
+    _vtk_create_cell(cell)
+
+Return the VTK cell type for a list of cell indices.
+"""
+function _vtk_create_cell(cell)
+    n = length(cell)
+    n==5 && return MeshCell(VTKCellTypes.VTK_PYRAMID, cell)
+    n==6 && return MeshCell(VTKCellTypes.VTK_WEDGE, cell)
+    n==8 && return MeshCell(VTKCellTypes.VTK_VOXEL, cell)
+end

--- a/src/Roentgen.jl
+++ b/src/Roentgen.jl
@@ -63,6 +63,8 @@ include("DoseVolume.jl")
 
 include("DoseReconstructions.jl")
 
+include("IO/VTK.jl")
+
 export calibrate!
 
 export load, save, write_vtk, write_nrrd

--- a/src/Structures.jl
+++ b/src/Structures.jl
@@ -109,22 +109,6 @@ function closest_intersection(p1, p2, mesh, args...)
     coordinates(pI[s])
 end
 
-#--- File IO ------------------------------------------------------------------
-
-"""
-    write_vtk(filename, mesh::SimpleMesh)
-
-Save a `SimpleMesh` to a VTK (.vtu) file.
-"""
-function write_vtk(filename, mesh::SimpleMesh)
-    id = [indices(e) for e in elements(topology(mesh))]
-    vtkfile = vtk_grid(filename,
-                       coordinates.(vertices(mesh)), 
-                       MeshCell.(Ref(VTKCellTypes.VTK_TRIANGLE), id))
-    vtk_save(vtkfile)
-end
-
-
 function isinside(testpoint::Point{3,T}, mesh::Mesh{3,T}) where T
     if !(eltype(mesh) <: Triangle)
       error("This function only works for surface meshes with triangles as elements.")


### PR DESCRIPTION
- Added a VTK writer for writing beamlets and collection of beamlets.
- Put all VTK and NRRD data writing code in src/IO files
- Added src/IO to codecov ignore. These functions are not critical to the operation of the library, and IO is a little tricky to test for in unit tests